### PR TITLE
Use newer Data.Some mkSome instead of This

### DIFF
--- a/reflex-dom-echarts.cabal
+++ b/reflex-dom-echarts.cabal
@@ -11,7 +11,7 @@ library
                , containers
                , data-default
                , ghcjs-dom
-               , dependent-sum
+               , dependent-sum >= 0.7.1.0
                , lens
                , scientific
                , text

--- a/src/Reflex/Dom/Widget/ECharts.hs
+++ b/src/Reflex/Dom/Widget/ECharts.hs
@@ -101,7 +101,7 @@ lineChart c = do
       vs :: [(Object, Event t (Int, JSVal))] <-
         forM (Map.elems $ _lineChartConfig_series c) $ \(s, dd, xd) -> do
           -- series options without the data
-          sVal <- liftJSM (makeObject =<< toJSVal (Some.mkSome $ SeriesT_Line s))
+          sVal <- liftJSM (makeObject =<< toJSVal (Some.Some $ SeriesT_Line s))
 
           let
             i = maybe 0 id (s ^. series_xAxisIndex)
@@ -191,7 +191,7 @@ timeLineChart c = do
 
       vs <- forM (Map.elems $ _timeLineChartConfig_appendData c) $ \(s, len, ev) -> do
         -- series object
-        sVal <- liftJSM (makeObject =<< toJSVal (Some.mkSome $ SeriesT_Line s))
+        sVal <- liftJSM (makeObject =<< toJSVal (Some.Some $ SeriesT_Line s))
 
         rec
           newArr <- performEvent $ ffor (attach (current arrDyn) ev) $ \(arr, vs) -> liftJSM $ do

--- a/src/Reflex/Dom/Widget/ECharts.hs
+++ b/src/Reflex/Dom/Widget/ECharts.hs
@@ -101,7 +101,7 @@ lineChart c = do
       vs :: [(Object, Event t (Int, JSVal))] <-
         forM (Map.elems $ _lineChartConfig_series c) $ \(s, dd, xd) -> do
           -- series options without the data
-          sVal <- liftJSM (makeObject =<< toJSVal (Some.This $ SeriesT_Line s))
+          sVal <- liftJSM (makeObject =<< toJSVal (Some.mkSome $ SeriesT_Line s))
 
           let
             i = maybe 0 id (s ^. series_xAxisIndex)
@@ -191,7 +191,7 @@ timeLineChart c = do
 
       vs <- forM (Map.elems $ _timeLineChartConfig_appendData c) $ \(s, len, ev) -> do
         -- series object
-        sVal <- liftJSM (makeObject =<< toJSVal (Some.This $ SeriesT_Line s))
+        sVal <- liftJSM (makeObject =<< toJSVal (Some.mkSome $ SeriesT_Line s))
 
         rec
           newArr <- performEvent $ ffor (attach (current arrDyn) ev) $ \(arr, vs) -> liftJSM $ do


### PR DESCRIPTION
This change allows this to be used with newer projects where Data.Some
no longer exports This